### PR TITLE
Extra build args, preseed support

### DIFF
--- a/DockerMake.yml
+++ b/DockerMake.yml
@@ -138,9 +138,11 @@ reclass:
     ENV SALT_ENV_PATH_ $SALT_ENV_PATH_
     ARG RECLASS_BASE="/srv/salt/reclass"
     ENV RECLASS_BASE $RECLASS_BASE
+    ARG RECLASS_BASE_SOURCE="https://github.com/Mirantis/reclass-system-salt-model"
+    ENV RECLASS_BASE_SOURCE $RECLASS_BASE_SOURCE
     RUN echo "Layer reclass" \
       && mkdir -p /etc/reclass $RECLASS_BASE/classes/system \
-      && git clone https://github.com/Mirantis/reclass-system-salt-model $RECLASS_BASE/classes/system \
+      && git clone --no-hardlinks $RECLASS_BASE_SOURCE $RECLASS_BASE/classes/system \
       && find $RECLASS_BASE/classes/system
     RUN pip install --install-option="--prefix=/usr/local" -I \
            "git+https://github.com/salt-formulas/reclass.git@$RECLASS_VERSION"

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@
 
 
 from invoke import Collection, task
+from shlex import split
 from string import Template
 import re
 import ast
@@ -25,7 +26,7 @@ def all(ctx, dry=False, push=False, dry_targets=False, filter=None, **kwargs):
                      dry=dry, push=push, dry_targets=dry_targets, filter=filter, **kwargs)
 
 @task
-def build(ctx, target, require=[], dist='debian', dist_rel='stretch', salt=None, formula_rev=None, push=False, dry=False, dry_targets=False, **kwargs):
+def build(ctx, target, require=[], dist='debian', dist_rel='stretch', salt=None, formula_rev=None, push=False, dry=False, dry_targets=False, build_arg_extra='', **kwargs):
 
     kwargs['dist'] = dist
     kwargs['dist_rel'] = dist_rel
@@ -35,6 +36,7 @@ def build(ctx, target, require=[], dist='debian', dist_rel='stretch', salt=None,
     kwargs['require'] = require
     kwargs['salt'] = salt
     kwargs['target'] = target
+    kwargs['build_arg_extra'] = ' --build-arg '.join([''] + split(build_arg_extra.replace('"', '"\\"')))
     # command formating + update
     fmt = {'tag': ''}
     fmt.update(ctx.dockermake)
@@ -60,6 +62,7 @@ def build(ctx, target, require=[], dist='debian', dist_rel='stretch', salt=None,
             \t--requires ${requires} \
             \t--build-arg SALT_VERSION="${salt}" \
             \t--build-arg SALT_FORMULA_VERSION="${formula_rev}" \
+            \t${build_arg_extra} \
             \t${push} ${options} \
             ${fin}""").safe_substitute(fmt)
     ctx.run(cmd.replace('  ', ''))


### PR DESCRIPTION
In OPNFV we pre-patch the reclass.sytem git repository with a few custom patches, so overriding its git remote URI via env vars could be really useful.