### PR TITLE
reclass: Set ignore_overwritten_missing_references

### DIFF
--- a/files/reclass/reclass-config.yml
+++ b/files/reclass/reclass-config.yml
@@ -3,6 +3,7 @@ inventory_base_uri: /srv/salt/reclass
 pretty_print: True
 output: yaml
 
+ignore_overwritten_missing_references: True
 ignore_class_notfound: True
 ignore_class_regexp:
 - 'service.*'


### PR DESCRIPTION
The recent changes in `reclass` 1.6.x allow configuring this new
option; however the default for it is broken - see [1].

[1] https://github.com/salt-formulas/reclass/issues/77